### PR TITLE
Add weather dashboard UI and Pages deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# weather-app-v3
+# Simple Weather Dashboard
+
+A lightweight single-page dashboard that displays the current temperature for four cities — Kyiv, Singapore, London, and Sydney — using live data from the Open-Meteo API.
+
+## Getting Started
+
+This project is built with vanilla HTML, CSS, and JavaScript. No build step is required.
+
+### Prerequisites
+
+* [Node.js 18+](https://nodejs.org/) for running the automated tests.
+
+### Local Development
+
+Open `index.html` in your browser or serve the project locally:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit [http://localhost:8000](http://localhost:8000).
+
+## Testing
+
+Run the automated test suite (with coverage) using Node's test runner:
+
+```bash
+npm test
+```
+
+## Deployment
+
+The project includes a GitHub Actions workflow (`.github/workflows/ci.yaml`) that runs tests and deploys the site to GitHub Pages when changes are pushed to the `main` branch.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Simple Weather Dashboard</title>
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Today's Weather</h1>
+        <p>Live temperatures for Kyiv, Singapore, London, and Sydney.</p>
+      </header>
+      <section id="weather-section" aria-live="polite" aria-busy="true">
+        <p id="status-message">Loading weather data...</p>
+        <ul id="city-weather-list" aria-label="City temperatures"></ul>
+      </section>
+    </main>
+    <script type="module" src="scripts/app.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "weather-app-v3",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,0 +1,85 @@
+import {
+  CITIES,
+  GENERIC_ERROR_MESSAGE,
+  LOADING_MESSAGE
+} from "./constants.js";
+import { fetchWeatherForCities } from "./weatherService.js";
+
+const DASHBOARD_LIST_ID = "city-weather-list";
+const STATUS_MESSAGE_ID = "status-message";
+const WEATHER_SECTION_ID = "weather-section";
+const CITY_CARD_CLASS = "city-card";
+const CITY_NAME_CLASS = "city-name";
+const TEMPERATURE_CLASS = "city-temperature";
+const FLAG_LABEL = "City flag";
+
+const getElement = (elementId) => document.getElementById(elementId);
+
+const setBusyState = (isBusy) => {
+  const section = getElement(WEATHER_SECTION_ID);
+  if (section) {
+    section.setAttribute("aria-busy", String(isBusy));
+  }
+};
+
+const createCityCard = (cityWeather) => {
+  const listItem = document.createElement("li");
+  listItem.className = CITY_CARD_CLASS;
+
+  const flag = document.createElement("span");
+  flag.setAttribute("role", "img");
+  flag.setAttribute("aria-label", `${cityWeather.name} ${FLAG_LABEL}`);
+  flag.textContent = cityWeather.flagEmoji;
+
+  const name = document.createElement("span");
+  name.className = CITY_NAME_CLASS;
+  name.textContent = cityWeather.name;
+
+  const temperature = document.createElement("span");
+  temperature.className = TEMPERATURE_CLASS;
+  temperature.textContent = cityWeather.temperature;
+
+  listItem.append(flag, name, temperature);
+  return listItem;
+};
+
+const renderStatusMessage = (message) => {
+  const statusElement = getElement(STATUS_MESSAGE_ID);
+  if (statusElement) {
+    statusElement.textContent = message;
+  }
+};
+
+const clearStatusMessage = () => renderStatusMessage("");
+
+const renderWeatherList = (weatherByCity) => {
+  const listElement = getElement(DASHBOARD_LIST_ID);
+  if (!listElement) {
+    return;
+  }
+
+  listElement.replaceChildren(...weatherByCity.map(createCityCard));
+};
+
+const handleError = (error) => {
+  console.error(error);
+  renderStatusMessage(GENERIC_ERROR_MESSAGE);
+  setBusyState(false);
+};
+
+const initializeDashboard = async () => {
+  setBusyState(true);
+  renderStatusMessage(LOADING_MESSAGE);
+  try {
+    const weatherByCity = await fetchWeatherForCities(CITIES);
+    clearStatusMessage();
+    renderWeatherList(weatherByCity);
+  } catch (error) {
+    handleError(error);
+    return;
+  }
+
+  setBusyState(false);
+};
+
+document.addEventListener("DOMContentLoaded", initializeDashboard);

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,0 +1,33 @@
+export const CITIES = [
+  {
+    name: "Kyiv",
+    latitude: 50.4501,
+    longitude: 30.5234,
+    flagEmoji: "🇺🇦"
+  },
+  {
+    name: "Singapore",
+    latitude: 1.3521,
+    longitude: 103.8198,
+    flagEmoji: "🇸🇬"
+  },
+  {
+    name: "London",
+    latitude: 51.5074,
+    longitude: -0.1278,
+    flagEmoji: "🇬🇧"
+  },
+  {
+    name: "Sydney",
+    latitude: -33.8688,
+    longitude: 151.2093,
+    flagEmoji: "🇦🇺"
+  }
+];
+
+export const WEATHER_API_BASE_URL = "https://api.open-meteo.com/v1/forecast";
+export const CURRENT_WEATHER_QUERY = "current_weather=true";
+export const TEMPERATURE_UNIT = "°C";
+export const LOADING_MESSAGE = "Loading weather data...";
+export const GENERIC_ERROR_MESSAGE = "Unable to load weather information right now. Please try again later.";
+export const TEMPERATURE_DECIMAL_PLACES = 1;

--- a/scripts/weatherService.js
+++ b/scripts/weatherService.js
@@ -1,0 +1,55 @@
+import {
+  CURRENT_WEATHER_QUERY,
+  TEMPERATURE_DECIMAL_PLACES,
+  TEMPERATURE_UNIT,
+  WEATHER_API_BASE_URL
+} from "./constants.js";
+
+const LATITUDE_QUERY_PARAM = "latitude";
+const LONGITUDE_QUERY_PARAM = "longitude";
+const CURRENT_WEATHER_KEY = "current_weather";
+const TEMPERATURE_KEY = "temperature";
+const DEFAULT_TIMEZONE_QUERY = "timezone=auto";
+
+const REQUIRED_QUERY_PARAMS = [CURRENT_WEATHER_QUERY, DEFAULT_TIMEZONE_QUERY];
+
+export const buildWeatherApiUrl = (latitude, longitude) => {
+  const apiUrl = new URL(WEATHER_API_BASE_URL);
+  apiUrl.searchParams.set(LATITUDE_QUERY_PARAM, latitude.toString());
+  apiUrl.searchParams.set(LONGITUDE_QUERY_PARAM, longitude.toString());
+  REQUIRED_QUERY_PARAMS.forEach((parameter) => {
+    const [key, value] = parameter.split("=");
+    apiUrl.searchParams.set(key, value);
+  });
+  return apiUrl.toString();
+};
+
+export const mapWeatherResponse = (city, apiResponse) => {
+  if (!apiResponse || !apiResponse[CURRENT_WEATHER_KEY]) {
+    throw new Error(`Missing weather data for ${city.name}`);
+  }
+
+  const currentWeather = apiResponse[CURRENT_WEATHER_KEY];
+  if (typeof currentWeather[TEMPERATURE_KEY] !== "number") {
+    throw new Error(`Missing temperature value for ${city.name}`);
+  }
+
+  return {
+    name: city.name,
+    flagEmoji: city.flagEmoji,
+    temperature: `${currentWeather[TEMPERATURE_KEY].toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`
+  };
+};
+
+export const fetchWeatherForCities = async (cities, fetchImplementation = fetch) => {
+  const weatherPromises = cities.map(async (city) => {
+    const response = await fetchImplementation(buildWeatherApiUrl(city.latitude, city.longitude));
+    if (!response.ok) {
+      throw new Error(`Weather request failed for ${city.name}`);
+    }
+    const apiResponse = await response.json();
+    return mapWeatherResponse(city, apiResponse);
+  });
+
+  return Promise.all(weatherPromises);
+};

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,124 @@
+:root {
+  --page-background: linear-gradient(135deg, #172554, #1d4ed8);
+  --card-background: rgba(255, 255, 255, 0.15);
+  --card-border: rgba(255, 255, 255, 0.4);
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5f5;
+  --font-family: "Inter", "Segoe UI", sans-serif;
+  --max-content-width: 480px;
+  --card-gap: 1rem;
+  --card-padding: 1rem;
+  --card-radius: 16px;
+  --card-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
+  --transition-duration: 200ms;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: var(--page-background);
+  font-family: var(--font-family);
+  color: var(--text-primary);
+}
+
+main {
+  width: min(100%, var(--max-content-width));
+  padding: 2.5rem 1.5rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  letter-spacing: 0.02em;
+}
+
+p {
+  margin: 0.5rem 0 0;
+  color: var(--text-secondary);
+}
+
+#status-message {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  min-height: 1.5rem;
+}
+
+#city-weather-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--card-gap);
+}
+
+.city-card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: var(--card-padding);
+  background: var(--card-background);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
+  backdrop-filter: blur(8px);
+  box-shadow: var(--card-shadow);
+  transition: transform var(--transition-duration) ease, box-shadow var(--transition-duration) ease;
+}
+
+.city-card:hover,
+.city-card:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.4);
+}
+
+.city-card span:first-child {
+  font-size: 2rem;
+}
+
+.city-name {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.city-temperature {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  main {
+    padding: 2rem 1rem;
+  }
+
+  .city-card {
+    grid-template-columns: auto auto;
+    grid-template-areas:
+      "flag name"
+      "flag temperature";
+  }
+
+  .city-card span:first-child {
+    grid-area: flag;
+  }
+
+  .city-name {
+    grid-area: name;
+  }
+
+  .city-temperature {
+    grid-area: temperature;
+    justify-self: end;
+  }
+}

--- a/tests/weatherService.test.js
+++ b/tests/weatherService.test.js
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, it, mock } from "node:test";
+
+import { CITIES, TEMPERATURE_DECIMAL_PLACES, TEMPERATURE_UNIT } from "../scripts/constants.js";
+import {
+  buildWeatherApiUrl,
+  fetchWeatherForCities,
+  mapWeatherResponse
+} from "../scripts/weatherService.js";
+
+const SAMPLE_CITY = CITIES[0];
+
+describe("buildWeatherApiUrl", () => {
+  it("includes coordinates and query parameters", () => {
+    const url = new URL(buildWeatherApiUrl(SAMPLE_CITY.latitude, SAMPLE_CITY.longitude));
+    assert.equal(url.origin + url.pathname, "https://api.open-meteo.com/v1/forecast");
+    assert.equal(url.searchParams.get("latitude"), SAMPLE_CITY.latitude.toString());
+    assert.equal(url.searchParams.get("longitude"), SAMPLE_CITY.longitude.toString());
+    assert.equal(url.searchParams.get("current_weather"), "true");
+    assert.equal(url.searchParams.get("timezone"), "auto");
+  });
+});
+
+describe("mapWeatherResponse", () => {
+  it("formats the response for rendering", () => {
+    const temperature = 21.3456;
+    const apiResponse = {
+      current_weather: {
+        temperature
+      }
+    };
+
+    const result = mapWeatherResponse(SAMPLE_CITY, apiResponse);
+    assert.deepEqual(result, {
+      name: SAMPLE_CITY.name,
+      flagEmoji: SAMPLE_CITY.flagEmoji,
+      temperature: `${temperature.toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`
+    });
+  });
+
+  it("throws when current weather block is missing", () => {
+    assert.throws(() => mapWeatherResponse(SAMPLE_CITY, {}), /Missing weather data/);
+  });
+
+  it("throws when the temperature is missing", () => {
+    const response = {
+      current_weather: {}
+    };
+    assert.throws(() => mapWeatherResponse(SAMPLE_CITY, response), /Missing temperature value/);
+  });
+});
+
+describe("fetchWeatherForCities", () => {
+  it("fetches weather for each provided city", async () => {
+    const apiResponse = {
+      current_weather: {
+        temperature: 19.87
+      }
+    };
+
+    const fetchMock = mock.fn(async () => ({
+      ok: true,
+      json: async () => apiResponse
+    }));
+
+    const result = await fetchWeatherForCities([SAMPLE_CITY], fetchMock);
+    assert.equal(fetchMock.mock.calls.length, 1);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, SAMPLE_CITY.name);
+  });
+
+  it("throws when the response is not ok", async () => {
+    const fetchMock = mock.fn(async () => ({
+      ok: false,
+      json: async () => ({})
+    }));
+
+    await assert.rejects(
+      fetchWeatherForCities([SAMPLE_CITY], fetchMock),
+      /Weather request failed/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a static dashboard that fetches live temperatures for Kyiv, Singapore, London, and Sydney
- implement vanilla JavaScript modules, styling, and tests for the weather fetching logic
- configure CI to run the test suite and deploy the site to GitHub Pages on main

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff24f17d08327a3d96e66c1d1b5c1