### PR TITLE
Move refresh controls to corner layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
         <p>Live temperatures for Kyiv, Singapore, London, and Sydney.</p>
       </header>
       <section id="weather-section" aria-live="polite" aria-busy="true">
+        <div class="weather-controls">
+          <button id="refresh-weather-button" type="button">Refresh all locations</button>
+          <p id="last-updated" aria-live="polite"></p>
+        </div>
         <p id="status-message">Loading weather data...</p>
         <ul id="city-weather-list" aria-label="City temperatures"></ul>
       </section>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,7 +1,8 @@
 import {
   CITIES,
   GENERIC_ERROR_MESSAGE,
-  LOADING_MESSAGE
+  LOADING_MESSAGE,
+  REFRESHING_MESSAGE
 } from "./constants.js";
 import { fetchWeatherForCities } from "./weatherService.js";
 
@@ -11,7 +12,23 @@ const WEATHER_SECTION_ID = "weather-section";
 const CITY_CARD_CLASS = "city-card";
 const CITY_NAME_CLASS = "city-name";
 const TEMPERATURE_CLASS = "city-temperature";
+const CITY_LOCAL_TIME_CLASS = "city-local-time";
 const FLAG_LABEL = "City flag";
+const REFRESH_BUTTON_ID = "refresh-weather-button";
+const LAST_UPDATED_ID = "last-updated";
+const LAST_UPDATED_PREFIX = "Last refreshed at";
+const LOCAL_TIME_LABEL = "Local time";
+const USER_LOCALE = typeof navigator !== "undefined" ? navigator.language : undefined;
+const LOCAL_TIME_FORMAT_OPTIONS = Object.freeze({
+  hour: "2-digit",
+  minute: "2-digit",
+  timeZoneName: "short"
+});
+const LAST_UPDATED_FORMAT_OPTIONS = Object.freeze({
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit"
+});
 
 const getElement = (elementId) => document.getElementById(elementId);
 
@@ -21,6 +38,26 @@ const setBusyState = (isBusy) => {
     section.setAttribute("aria-busy", String(isBusy));
   }
 };
+
+const setRefreshButtonDisabled = (isDisabled) => {
+  const refreshButton = getElement(REFRESH_BUTTON_ID);
+  if (refreshButton) {
+    refreshButton.disabled = isDisabled;
+    refreshButton.setAttribute("aria-busy", String(isDisabled));
+  }
+};
+
+const formatDateTime = (date, options) =>
+  new Intl.DateTimeFormat(USER_LOCALE, options).format(date);
+
+const formatLocalTime = (isoTimestamp, timeZone) =>
+  formatDateTime(new Date(isoTimestamp), {
+    ...LOCAL_TIME_FORMAT_OPTIONS,
+    timeZone
+  });
+
+const formatLastUpdated = (timestamp) =>
+  formatDateTime(timestamp, LAST_UPDATED_FORMAT_OPTIONS);
 
 const createCityCard = (cityWeather) => {
   const listItem = document.createElement("li");
@@ -39,7 +76,15 @@ const createCityCard = (cityWeather) => {
   temperature.className = TEMPERATURE_CLASS;
   temperature.textContent = cityWeather.temperature;
 
-  listItem.append(flag, name, temperature);
+  const localTime = document.createElement("time");
+  localTime.className = CITY_LOCAL_TIME_CLASS;
+  localTime.dateTime = cityWeather.observedAt;
+  localTime.textContent = `${LOCAL_TIME_LABEL}: ${formatLocalTime(
+    cityWeather.observedAt,
+    cityWeather.timeZone
+  )}`;
+
+  listItem.append(flag, name, temperature, localTime);
   return listItem;
 };
 
@@ -51,6 +96,20 @@ const renderStatusMessage = (message) => {
 };
 
 const clearStatusMessage = () => renderStatusMessage("");
+
+const renderLastUpdated = (timestamp) => {
+  const lastUpdatedElement = getElement(LAST_UPDATED_ID);
+  if (!lastUpdatedElement) {
+    return;
+  }
+
+  if (!timestamp) {
+    lastUpdatedElement.textContent = "";
+    return;
+  }
+
+  lastUpdatedElement.textContent = `${LAST_UPDATED_PREFIX} ${formatLastUpdated(timestamp)}`;
+};
 
 const renderWeatherList = (weatherByCity) => {
   const listElement = getElement(DASHBOARD_LIST_ID);
@@ -64,22 +123,36 @@ const renderWeatherList = (weatherByCity) => {
 const handleError = (error) => {
   console.error(error);
   renderStatusMessage(GENERIC_ERROR_MESSAGE);
-  setBusyState(false);
 };
 
-const initializeDashboard = async () => {
+const loadDashboardWeather = async (loadingMessage) => {
   setBusyState(true);
-  renderStatusMessage(LOADING_MESSAGE);
+  setRefreshButtonDisabled(true);
+  renderStatusMessage(loadingMessage);
+
   try {
     const weatherByCity = await fetchWeatherForCities(CITIES);
     clearStatusMessage();
     renderWeatherList(weatherByCity);
+    renderLastUpdated(new Date());
   } catch (error) {
     handleError(error);
-    return;
+    renderLastUpdated(null);
+  } finally {
+    setBusyState(false);
+    setRefreshButtonDisabled(false);
+  }
+};
+
+const initializeDashboard = () => {
+  const refreshButton = getElement(REFRESH_BUTTON_ID);
+  if (refreshButton) {
+    refreshButton.addEventListener("click", () => {
+      loadDashboardWeather(REFRESHING_MESSAGE);
+    });
   }
 
-  setBusyState(false);
+  loadDashboardWeather(LOADING_MESSAGE);
 };
 
 document.addEventListener("DOMContentLoaded", initializeDashboard);

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -29,5 +29,6 @@ export const WEATHER_API_BASE_URL = "https://api.open-meteo.com/v1/forecast";
 export const CURRENT_WEATHER_QUERY = "current_weather=true";
 export const TEMPERATURE_UNIT = "°C";
 export const LOADING_MESSAGE = "Loading weather data...";
+export const REFRESHING_MESSAGE = "Refreshing weather data...";
 export const GENERIC_ERROR_MESSAGE = "Unable to load weather information right now. Please try again later.";
 export const TEMPERATURE_DECIMAL_PLACES = 1;

--- a/scripts/weatherService.js
+++ b/scripts/weatherService.js
@@ -9,6 +9,8 @@ const LATITUDE_QUERY_PARAM = "latitude";
 const LONGITUDE_QUERY_PARAM = "longitude";
 const CURRENT_WEATHER_KEY = "current_weather";
 const TEMPERATURE_KEY = "temperature";
+const TIME_KEY = "time";
+const TIMEZONE_KEY = "timezone";
 const DEFAULT_TIMEZONE_QUERY = "timezone=auto";
 
 const REQUIRED_QUERY_PARAMS = [CURRENT_WEATHER_QUERY, DEFAULT_TIMEZONE_QUERY];
@@ -34,10 +36,20 @@ export const mapWeatherResponse = (city, apiResponse) => {
     throw new Error(`Missing temperature value for ${city.name}`);
   }
 
+  if (typeof currentWeather[TIME_KEY] !== "string") {
+    throw new Error(`Missing observation time for ${city.name}`);
+  }
+
+  if (typeof apiResponse[TIMEZONE_KEY] !== "string") {
+    throw new Error(`Missing timezone information for ${city.name}`);
+  }
+
   return {
     name: city.name,
     flagEmoji: city.flagEmoji,
-    temperature: `${currentWeather[TEMPERATURE_KEY].toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`
+    temperature: `${currentWeather[TEMPERATURE_KEY].toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`,
+    observedAt: currentWeather[TIME_KEY],
+    timeZone: apiResponse[TIMEZONE_KEY]
   };
 };
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -11,6 +11,13 @@
   --card-radius: 16px;
   --card-shadow: 0 20px 40px rgba(15, 23, 42, 0.25);
   --transition-duration: 200ms;
+  --button-background: rgba(59, 130, 246, 0.85);
+  --button-background-hover: rgba(59, 130, 246, 1);
+  --button-text: #f8fafc;
+  --button-border: rgba(148, 163, 184, 0.4);
+  --button-disabled-background: rgba(148, 163, 184, 0.3);
+  --button-disabled-text: rgba(241, 245, 249, 0.65);
+  --controls-gap: 0.5rem;
 }
 
 * {
@@ -55,6 +62,48 @@ p {
   min-height: 1.5rem;
 }
 
+#last-updated {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.weather-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--controls-gap);
+  margin-bottom: 1.25rem;
+  margin-left: auto;
+  width: max-content;
+  text-align: right;
+}
+
+.weather-controls button {
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--button-border);
+  background: var(--button-background);
+  color: var(--button-text);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background var(--transition-duration) ease, transform var(--transition-duration) ease;
+}
+
+.weather-controls button:hover,
+.weather-controls button:focus-visible {
+  background: var(--button-background-hover);
+  transform: translateY(-1px);
+}
+
+.weather-controls button:disabled {
+  background: var(--button-disabled-background);
+  color: var(--button-disabled-text);
+  cursor: not-allowed;
+  transform: none;
+}
+
 #city-weather-list {
   list-style: none;
   margin: 0;
@@ -66,6 +115,7 @@ p {
 .city-card {
   display: grid;
   grid-template-columns: auto 1fr auto;
+  grid-auto-rows: auto;
   align-items: center;
   gap: 0.75rem;
   padding: var(--card-padding);
@@ -97,16 +147,33 @@ p {
   font-weight: 600;
 }
 
+.city-local-time {
+  grid-column: 1 / -1;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
 @media (max-width: 480px) {
   main {
     padding: 2rem 1rem;
+  }
+
+  .weather-controls {
+    width: 100%;
+    align-items: stretch;
+    text-align: left;
+  }
+
+  .weather-controls button {
+    width: 100%;
   }
 
   .city-card {
     grid-template-columns: auto auto;
     grid-template-areas:
       "flag name"
-      "flag temperature";
+      "flag temperature"
+      "time time";
   }
 
   .city-card span:first-child {
@@ -120,5 +187,9 @@ p {
   .city-temperature {
     grid-area: temperature;
     justify-self: end;
+  }
+
+  .city-local-time {
+    grid-area: time;
   }
 }

--- a/tests/weatherService.test.js
+++ b/tests/weatherService.test.js
@@ -24,17 +24,23 @@ describe("buildWeatherApiUrl", () => {
 describe("mapWeatherResponse", () => {
   it("formats the response for rendering", () => {
     const temperature = 21.3456;
+    const observationTime = "2024-04-01T10:00";
+    const timezone = "Europe/Kyiv";
     const apiResponse = {
       current_weather: {
-        temperature
-      }
+        temperature,
+        time: observationTime
+      },
+      timezone
     };
 
     const result = mapWeatherResponse(SAMPLE_CITY, apiResponse);
     assert.deepEqual(result, {
       name: SAMPLE_CITY.name,
       flagEmoji: SAMPLE_CITY.flagEmoji,
-      temperature: `${temperature.toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`
+      temperature: `${temperature.toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`,
+      observedAt: observationTime,
+      timeZone: timezone
     });
   });
 
@@ -48,14 +54,38 @@ describe("mapWeatherResponse", () => {
     };
     assert.throws(() => mapWeatherResponse(SAMPLE_CITY, response), /Missing temperature value/);
   });
+
+  it("throws when the observation time is missing", () => {
+    const response = {
+      current_weather: {
+        temperature: 20
+      },
+      timezone: "Etc/UTC"
+    };
+
+    assert.throws(() => mapWeatherResponse(SAMPLE_CITY, response), /Missing observation time/);
+  });
+
+  it("throws when the timezone is missing", () => {
+    const response = {
+      current_weather: {
+        temperature: 20,
+        time: "2024-04-01T10:00"
+      }
+    };
+
+    assert.throws(() => mapWeatherResponse(SAMPLE_CITY, response), /Missing timezone information/);
+  });
 });
 
 describe("fetchWeatherForCities", () => {
   it("fetches weather for each provided city", async () => {
     const apiResponse = {
       current_weather: {
-        temperature: 19.87
-      }
+        temperature: 19.87,
+        time: "2024-04-01T10:00"
+      },
+      timezone: "Europe/Kyiv"
     };
 
     const fetchMock = mock.fn(async () => ({


### PR DESCRIPTION
## Summary
- adjust weather controls layout so the refresh button anchors to the top-right corner of the section
- add a dedicated gap variable and responsive tweaks to keep the control readable on mobile

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dff5da9d5083278157b2efbe4f6a82