### PR TITLE
Switch city management to dropdown catalog

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,20 @@
     <main>
       <header>
         <h1>Today's Weather</h1>
-        <p>Live temperatures for Kyiv, Singapore, London, and Sydney.</p>
+        <p>Live temperatures for your favourite cities.</p>
       </header>
+      <section id="city-management" aria-label="Add a city to the dashboard">
+        <h2>Manage cities</h2>
+        <form id="city-form">
+          <div class="form-row">
+            <label for="city-select">City</label>
+            <select id="city-select" name="city-select" required>
+              <option value="">Select a city…</option>
+            </select>
+          </div>
+          <button type="submit">Add city</button>
+        </form>
+      </section>
       <section id="weather-section" aria-live="polite" aria-busy="true">
         <p id="status-message">Loading weather data...</p>
         <ul id="city-weather-list" aria-label="City temperatures"></ul>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -8,12 +8,27 @@ import { fetchWeatherForCities } from "./weatherService.js";
 const DASHBOARD_LIST_ID = "city-weather-list";
 const STATUS_MESSAGE_ID = "status-message";
 const WEATHER_SECTION_ID = "weather-section";
+const CITY_FORM_ID = "city-form";
+const CITY_SELECT_ID = "city-select";
 const CITY_CARD_CLASS = "city-card";
 const CITY_NAME_CLASS = "city-name";
 const TEMPERATURE_CLASS = "city-temperature";
+const CITY_REMOVE_BUTTON_CLASS = "city-remove-button";
 const FLAG_LABEL = "City flag";
+const REMOVE_BUTTON_TEXT = "Remove";
+const REMOVE_BUTTON_LABEL_PREFIX = "Remove weather card for";
+const CITY_CARD_DATA_ATTRIBUTE = "cityKey";
+const CITY_KEY_SEPARATOR = "|";
+const DEFAULT_DASHBOARD_CITY_COUNT = 4;
+const CITY_SELECT_PLACEHOLDER_VALUE = "";
 
-const getElement = (elementId) => document.getElementById(elementId);
+export const NO_CITIES_MESSAGE = "No cities selected yet. Add a city to see the weather.";
+export const DUPLICATE_CITY_MESSAGE = "That city is already on the dashboard.";
+export const SELECT_CITY_PROMPT_MESSAGE = "Choose a city from the list before adding it.";
+
+function getElement(elementId) {
+  return document.getElementById(elementId);
+}
 
 const setBusyState = (isBusy) => {
   const section = getElement(WEATHER_SECTION_ID);
@@ -22,9 +37,24 @@ const setBusyState = (isBusy) => {
   }
 };
 
+export const createCityKey = (city) => {
+  const normalizedName = city.name.trim().toLowerCase();
+  return `${normalizedName}${CITY_KEY_SEPARATOR}${city.latitude}${CITY_KEY_SEPARATOR}${city.longitude}`;
+};
+
+const createWeatherWithKey = (city, weather) => ({
+  ...weather,
+  key: createCityKey(city)
+});
+
+const trackedCities = CITIES.slice(0, DEFAULT_DASHBOARD_CITY_COUNT);
+const trackedCityKeys = new Set(trackedCities.map((city) => createCityKey(city)));
+let currentWeather = [];
+
 const createCityCard = (cityWeather) => {
   const listItem = document.createElement("li");
   listItem.className = CITY_CARD_CLASS;
+  listItem.dataset[CITY_CARD_DATA_ATTRIBUTE] = cityWeather.key;
 
   const flag = document.createElement("span");
   flag.setAttribute("role", "img");
@@ -39,7 +69,13 @@ const createCityCard = (cityWeather) => {
   temperature.className = TEMPERATURE_CLASS;
   temperature.textContent = cityWeather.temperature;
 
-  listItem.append(flag, name, temperature);
+  const removeButton = document.createElement("button");
+  removeButton.type = "button";
+  removeButton.className = CITY_REMOVE_BUTTON_CLASS;
+  removeButton.setAttribute("aria-label", `${REMOVE_BUTTON_LABEL_PREFIX} ${cityWeather.name}`);
+  removeButton.textContent = REMOVE_BUTTON_TEXT;
+
+  listItem.append(flag, name, temperature, removeButton);
   return listItem;
 };
 
@@ -61,25 +97,183 @@ const renderWeatherList = (weatherByCity) => {
   listElement.replaceChildren(...weatherByCity.map(createCityCard));
 };
 
+const updateWeatherState = (weatherByCity) => {
+  currentWeather = weatherByCity;
+  renderWeatherList(currentWeather);
+  if (currentWeather.length === 0) {
+    renderStatusMessage(NO_CITIES_MESSAGE);
+    return;
+  }
+  clearStatusMessage();
+};
+
 const handleError = (error) => {
   console.error(error);
   renderStatusMessage(GENERIC_ERROR_MESSAGE);
   setBusyState(false);
 };
 
-const initializeDashboard = async () => {
-  setBusyState(true);
-  renderStatusMessage(LOADING_MESSAGE);
-  try {
-    const weatherByCity = await fetchWeatherForCities(CITIES);
-    clearStatusMessage();
-    renderWeatherList(weatherByCity);
-  } catch (error) {
-    handleError(error);
+const updateCitySelectOptions = () => {
+  const selectElement = getElement(CITY_SELECT_ID);
+  if (!(selectElement instanceof HTMLSelectElement)) {
     return;
   }
 
-  setBusyState(false);
+  Array.from(selectElement.options).forEach((option) => {
+    if (option.value === CITY_SELECT_PLACEHOLDER_VALUE) {
+      option.disabled = trackedCityKeys.size === CITIES.length;
+      return;
+    }
+    option.disabled = trackedCityKeys.has(option.value);
+  });
+
+  if (trackedCityKeys.size === CITIES.length) {
+    selectElement.value = CITY_SELECT_PLACEHOLDER_VALUE;
+    selectElement.disabled = true;
+  } else {
+    selectElement.disabled = false;
+  }
+};
+
+const populateCitySelect = () => {
+  const selectElement = getElement(CITY_SELECT_ID);
+  if (!(selectElement instanceof HTMLSelectElement)) {
+    return;
+  }
+
+  const existingOptions = new Set(Array.from(selectElement.options).map((option) => option.value));
+  CITIES.forEach((city) => {
+    const cityKey = createCityKey(city);
+    if (existingOptions.has(cityKey)) {
+      return;
+    }
+
+    const option = document.createElement("option");
+    option.value = cityKey;
+    option.textContent = `${city.flagEmoji} ${city.name}`;
+    selectElement.append(option);
+  });
+
+  updateCitySelectOptions();
+};
+
+const findCityByKey = (cityKey) => CITIES.find((city) => createCityKey(city) === cityKey);
+
+const removeCityByKey = (cityKey) => {
+  if (!cityKey) {
+    return;
+  }
+
+  const cityIndex = trackedCities.findIndex((city) => createCityKey(city) === cityKey);
+  if (cityIndex === -1) {
+    return;
+  }
+
+  trackedCities.splice(cityIndex, 1);
+  trackedCityKeys.delete(cityKey);
+  const updatedWeather = currentWeather.filter((cityWeather) => cityWeather.key !== cityKey);
+  updateWeatherState(updatedWeather);
+  updateCitySelectOptions();
+};
+
+const handleCityFormSubmit = async (event) => {
+  event.preventDefault();
+  const formElement = event.currentTarget;
+  if (!(formElement instanceof HTMLFormElement)) {
+    return;
+  }
+
+  const selectElement = formElement.querySelector(`#${CITY_SELECT_ID}`);
+  if (!(selectElement instanceof HTMLSelectElement)) {
+    return;
+  }
+
+  const selectedKey = selectElement.value;
+  if (!selectedKey || selectedKey === CITY_SELECT_PLACEHOLDER_VALUE) {
+    renderStatusMessage(SELECT_CITY_PROMPT_MESSAGE);
+    return;
+  }
+
+  if (trackedCityKeys.has(selectedKey)) {
+    renderStatusMessage(DUPLICATE_CITY_MESSAGE);
+    formElement.reset();
+    updateCitySelectOptions();
+    return;
+  }
+
+  const selectedCity = findCityByKey(selectedKey);
+  if (!selectedCity) {
+    renderStatusMessage(SELECT_CITY_PROMPT_MESSAGE);
+    return;
+  }
+
+  setBusyState(true);
+  renderStatusMessage(LOADING_MESSAGE);
+
+  try {
+    const [cityWeather] = await fetchWeatherForCities([selectedCity]);
+    trackedCities.push(selectedCity);
+    trackedCityKeys.add(selectedKey);
+    const updatedWeather = [...currentWeather, createWeatherWithKey(selectedCity, cityWeather)];
+    updateWeatherState(updatedWeather);
+    formElement.reset();
+    updateCitySelectOptions();
+  } catch (error) {
+    handleError(error);
+    return;
+  } finally {
+    setBusyState(false);
+  }
+};
+
+const handleWeatherListClick = (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  if (!target.classList.contains(CITY_REMOVE_BUTTON_CLASS)) {
+    return;
+  }
+
+  const listItem = target.closest(`.${CITY_CARD_CLASS}`);
+  if (!listItem) {
+    return;
+  }
+
+  const cityKey = listItem.dataset[CITY_CARD_DATA_ATTRIBUTE];
+  removeCityByKey(cityKey);
+};
+
+const attachEventListeners = () => {
+  const formElement = getElement(CITY_FORM_ID);
+  if (formElement instanceof HTMLFormElement) {
+    formElement.addEventListener("submit", handleCityFormSubmit);
+  }
+
+  const listElement = getElement(DASHBOARD_LIST_ID);
+  if (listElement) {
+    listElement.addEventListener("click", handleWeatherListClick);
+  }
+};
+
+const initializeDashboard = async () => {
+  populateCitySelect();
+  attachEventListeners();
+  setBusyState(true);
+  renderStatusMessage(LOADING_MESSAGE);
+  try {
+    const weatherByCity = await fetchWeatherForCities(trackedCities);
+    const weatherWithKeys = weatherByCity.map((cityWeather, index) =>
+      createWeatherWithKey(trackedCities[index], cityWeather)
+    );
+    updateWeatherState(weatherWithKeys);
+  } catch (error) {
+    handleError(error);
+    return;
+  } finally {
+    setBusyState(false);
+  }
 };
 
 document.addEventListener("DOMContentLoaded", initializeDashboard);

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,15 +1,9 @@
 export const CITIES = [
   {
-    name: "Kyiv",
-    latitude: 50.4501,
-    longitude: 30.5234,
-    flagEmoji: "🇺🇦"
-  },
-  {
-    name: "Singapore",
-    latitude: 1.3521,
-    longitude: 103.8198,
-    flagEmoji: "🇸🇬"
+    name: "New York City",
+    latitude: 40.7128,
+    longitude: -74.006,
+    flagEmoji: "🇺🇸"
   },
   {
     name: "London",
@@ -18,10 +12,172 @@ export const CITIES = [
     flagEmoji: "🇬🇧"
   },
   {
+    name: "Tokyo",
+    latitude: 35.6762,
+    longitude: 139.6503,
+    flagEmoji: "🇯🇵"
+  },
+  {
+    name: "Paris",
+    latitude: 48.8566,
+    longitude: 2.3522,
+    flagEmoji: "🇫🇷"
+  },
+  {
+    name: "Singapore",
+    latitude: 1.3521,
+    longitude: 103.8198,
+    flagEmoji: "🇸🇬"
+  },
+  {
     name: "Sydney",
     latitude: -33.8688,
     longitude: 151.2093,
     flagEmoji: "🇦🇺"
+  },
+  {
+    name: "Dubai",
+    latitude: 25.2048,
+    longitude: 55.2708,
+    flagEmoji: "🇦🇪"
+  },
+  {
+    name: "Hong Kong",
+    latitude: 22.3193,
+    longitude: 114.1694,
+    flagEmoji: "🇭🇰"
+  },
+  {
+    name: "Los Angeles",
+    latitude: 34.0522,
+    longitude: -118.2437,
+    flagEmoji: "🇺🇸"
+  },
+  {
+    name: "Mexico City",
+    latitude: 19.4326,
+    longitude: -99.1332,
+    flagEmoji: "🇲🇽"
+  },
+  {
+    name: "São Paulo",
+    latitude: -23.5505,
+    longitude: -46.6333,
+    flagEmoji: "🇧🇷"
+  },
+  {
+    name: "Buenos Aires",
+    latitude: -34.6037,
+    longitude: -58.3816,
+    flagEmoji: "🇦🇷"
+  },
+  {
+    name: "Toronto",
+    latitude: 43.6532,
+    longitude: -79.3832,
+    flagEmoji: "🇨🇦"
+  },
+  {
+    name: "Chicago",
+    latitude: 41.8781,
+    longitude: -87.6298,
+    flagEmoji: "🇺🇸"
+  },
+  {
+    name: "Madrid",
+    latitude: 40.4168,
+    longitude: -3.7038,
+    flagEmoji: "🇪🇸"
+  },
+  {
+    name: "Barcelona",
+    latitude: 41.3851,
+    longitude: 2.1734,
+    flagEmoji: "🇪🇸"
+  },
+  {
+    name: "Rome",
+    latitude: 41.9028,
+    longitude: 12.4964,
+    flagEmoji: "🇮🇹"
+  },
+  {
+    name: "Berlin",
+    latitude: 52.52,
+    longitude: 13.405,
+    flagEmoji: "🇩🇪"
+  },
+  {
+    name: "Amsterdam",
+    latitude: 52.3676,
+    longitude: 4.9041,
+    flagEmoji: "🇳🇱"
+  },
+  {
+    name: "Zurich",
+    latitude: 47.3769,
+    longitude: 8.5417,
+    flagEmoji: "🇨🇭"
+  },
+  {
+    name: "Stockholm",
+    latitude: 59.3293,
+    longitude: 18.0686,
+    flagEmoji: "🇸🇪"
+  },
+  {
+    name: "Helsinki",
+    latitude: 60.1699,
+    longitude: 24.9384,
+    flagEmoji: "🇫🇮"
+  },
+  {
+    name: "Cape Town",
+    latitude: -33.9249,
+    longitude: 18.4241,
+    flagEmoji: "🇿🇦"
+  },
+  {
+    name: "Johannesburg",
+    latitude: -26.2041,
+    longitude: 28.0473,
+    flagEmoji: "🇿🇦"
+  },
+  {
+    name: "Nairobi",
+    latitude: -1.2921,
+    longitude: 36.8219,
+    flagEmoji: "🇰🇪"
+  },
+  {
+    name: "Cairo",
+    latitude: 30.0444,
+    longitude: 31.2357,
+    flagEmoji: "🇪🇬"
+  },
+  {
+    name: "Seoul",
+    latitude: 37.5665,
+    longitude: 126.978,
+    flagEmoji: "🇰🇷"
+  },
+  {
+    name: "Bangkok",
+    latitude: 13.7563,
+    longitude: 100.5018,
+    flagEmoji: "🇹🇭"
+  },
+  {
+    name: "Istanbul",
+    latitude: 41.0082,
+    longitude: 28.9784,
+    flagEmoji: "🇹🇷"
+  },
+  {
+    name: "Kyiv",
+    latitude: 50.4501,
+    longitude: 30.5234,
+    flagEmoji: "🇺🇦"
   }
 ];
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -44,6 +44,85 @@ h1 {
   letter-spacing: 0.02em;
 }
 
+#city-management {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  padding: 1.25rem;
+  background: var(--card-background);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+}
+
+#city-management h2 {
+  margin: 0;
+  font-size: 1.125rem;
+  letter-spacing: 0.02em;
+}
+
+#city-management form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+#city-management label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+#city-management input,
+#city-management select {
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--card-border);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+#city-management input:focus-visible,
+#city-management select:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.65);
+  outline-offset: 2px;
+}
+
+#city-management select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, rgba(248, 250, 252, 0.65) 50%),
+    linear-gradient(135deg, rgba(248, 250, 252, 0.65) 50%, transparent 50%);
+  background-position: calc(100% - 1.6rem) calc(50% - 0.25rem), calc(100% - 1.1rem) calc(50% - 0.25rem);
+  background-size: 0.5rem 0.5rem, 0.5rem 0.5rem;
+  background-repeat: no-repeat;
+}
+
+#city-management button {
+  justify-self: start;
+  padding: 0.65rem 1.25rem;
+  border: none;
+  border-radius: 0.75rem;
+  background: rgba(59, 130, 246, 0.9);
+  color: var(--text-primary);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform var(--transition-duration) ease, box-shadow var(--transition-duration) ease;
+}
+
+#city-management button:hover,
+#city-management button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
+}
+
 p {
   margin: 0.5rem 0 0;
   color: var(--text-secondary);
@@ -65,7 +144,7 @@ p {
 
 .city-card {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto auto;
   align-items: center;
   gap: 0.75rem;
   padding: var(--card-padding);
@@ -97,6 +176,23 @@ p {
   font-weight: 600;
 }
 
+.city-remove-button {
+  padding: 0.4rem 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background var(--transition-duration) ease, color var(--transition-duration) ease;
+}
+
+.city-remove-button:hover,
+.city-remove-button:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--text-primary);
+}
+
 @media (max-width: 480px) {
   main {
     padding: 2rem 1rem;
@@ -106,7 +202,8 @@ p {
     grid-template-columns: auto auto;
     grid-template-areas:
       "flag name"
-      "flag temperature";
+      "flag temperature"
+      "flag remove";
   }
 
   .city-card span:first-child {
@@ -119,6 +216,11 @@ p {
 
   .city-temperature {
     grid-area: temperature;
+    justify-self: end;
+  }
+
+  .city-remove-button {
+    grid-area: remove;
     justify-self: end;
   }
 }

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,57 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+
+import { CITIES } from "../scripts/constants.js";
+
+global.document = {
+  addEventListener: () => {},
+  getElementById: () => null
+};
+global.HTMLElement = class {};
+global.HTMLFormElement = class {};
+global.HTMLSelectElement = class {};
+
+const appModule = await import("../scripts/app.js");
+
+const {
+  createCityKey,
+  NO_CITIES_MESSAGE,
+  DUPLICATE_CITY_MESSAGE,
+  SELECT_CITY_PROMPT_MESSAGE
+} = appModule;
+
+after(() => {
+  delete global.document;
+  delete global.HTMLElement;
+  delete global.HTMLFormElement;
+  delete global.HTMLSelectElement;
+});
+
+test("createCityKey combines normalized name and coordinates", () => {
+  const firstKey = createCityKey({
+    name: "  London  ",
+    latitude: 51.5074,
+    longitude: -0.1278
+  });
+  const secondKey = createCityKey({
+    name: "london",
+    latitude: 51.5074,
+    longitude: -0.1278
+  });
+
+  assert.strictEqual(firstKey, secondKey);
+  assert.ok(firstKey.includes("51.5074"));
+  assert.ok(firstKey.includes("-0.1278"));
+});
+
+test("city catalogue exposes thirty unique options", () => {
+  assert.strictEqual(CITIES.length, 30);
+  const uniqueKeys = new Set(CITIES.map(createCityKey));
+  assert.strictEqual(uniqueKeys.size, CITIES.length);
+});
+
+test("dashboard messages remain accessible", () => {
+  assert.ok(NO_CITIES_MESSAGE.length > 0);
+  assert.ok(DUPLICATE_CITY_MESSAGE.length > 0);
+  assert.ok(SELECT_CITY_PROMPT_MESSAGE.length > 0);
+});


### PR DESCRIPTION
## Summary
- replace the free-form city form with a dropdown backed by a curated list of 30 popular cities
- update dashboard logic to manage select state, prevent duplicates, and fetch weather for catalogued cities only
- refresh styles and tests to align with the dropdown workflow and static city data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff6170ed8832792806efa2cb91310