### PR TITLE
Add temperature-aware styling to weather cards

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -4,6 +4,7 @@ import {
   LOADING_MESSAGE
 } from "./constants.js";
 import { fetchWeatherForCities } from "./weatherService.js";
+import { getCityCardTemperatureClass } from "./temperatureStyles.js";
 
 const DASHBOARD_LIST_ID = "city-weather-list";
 const STATUS_MESSAGE_ID = "status-message";
@@ -24,7 +25,7 @@ const setBusyState = (isBusy) => {
 
 const createCityCard = (cityWeather) => {
   const listItem = document.createElement("li");
-  listItem.className = CITY_CARD_CLASS;
+  listItem.className = `${CITY_CARD_CLASS} ${getCityCardTemperatureClass(cityWeather.temperatureCelsius)}`;
 
   const flag = document.createElement("span");
   flag.setAttribute("role", "img");
@@ -37,7 +38,7 @@ const createCityCard = (cityWeather) => {
 
   const temperature = document.createElement("span");
   temperature.className = TEMPERATURE_CLASS;
-  temperature.textContent = cityWeather.temperature;
+  temperature.textContent = cityWeather.formattedTemperature;
 
   listItem.append(flag, name, temperature);
   return listItem;

--- a/scripts/temperatureStyles.js
+++ b/scripts/temperatureStyles.js
@@ -1,0 +1,28 @@
+const FREEZING_MAX_TEMPERATURE_CELSIUS = 0;
+const COOL_MAX_TEMPERATURE_CELSIUS = 15;
+const WARM_MAX_TEMPERATURE_CELSIUS = 25;
+
+const CITY_CARD_FREEZING_CLASS = "city-card--freezing";
+const CITY_CARD_COOL_CLASS = "city-card--cool";
+const CITY_CARD_WARM_CLASS = "city-card--warm";
+const CITY_CARD_HOT_CLASS = "city-card--hot";
+
+export const getCityCardTemperatureClass = (temperatureCelsius) => {
+  if (!Number.isFinite(temperatureCelsius)) {
+    throw new Error("Temperature must be a finite number.");
+  }
+
+  if (temperatureCelsius <= FREEZING_MAX_TEMPERATURE_CELSIUS) {
+    return CITY_CARD_FREEZING_CLASS;
+  }
+
+  if (temperatureCelsius <= COOL_MAX_TEMPERATURE_CELSIUS) {
+    return CITY_CARD_COOL_CLASS;
+  }
+
+  if (temperatureCelsius <= WARM_MAX_TEMPERATURE_CELSIUS) {
+    return CITY_CARD_WARM_CLASS;
+  }
+
+  return CITY_CARD_HOT_CLASS;
+};

--- a/scripts/weatherService.js
+++ b/scripts/weatherService.js
@@ -30,14 +30,16 @@ export const mapWeatherResponse = (city, apiResponse) => {
   }
 
   const currentWeather = apiResponse[CURRENT_WEATHER_KEY];
-  if (typeof currentWeather[TEMPERATURE_KEY] !== "number") {
+  const rawTemperature = currentWeather[TEMPERATURE_KEY];
+  if (!Number.isFinite(rawTemperature)) {
     throw new Error(`Missing temperature value for ${city.name}`);
   }
 
   return {
     name: city.name,
     flagEmoji: city.flagEmoji,
-    temperature: `${currentWeather[TEMPERATURE_KEY].toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`
+    temperatureCelsius: rawTemperature,
+    formattedTemperature: `${rawTemperature.toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`
   };
 };
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -77,6 +77,26 @@ p {
   transition: transform var(--transition-duration) ease, box-shadow var(--transition-duration) ease;
 }
 
+.city-card--freezing {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.35), rgba(147, 197, 253, 0.3));
+  border-color: rgba(147, 197, 253, 0.75);
+}
+
+.city-card--cool {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.35), rgba(16, 185, 129, 0.3));
+  border-color: rgba(94, 234, 212, 0.7);
+}
+
+.city-card--warm {
+  background: linear-gradient(135deg, rgba(251, 191, 36, 0.35), rgba(252, 211, 77, 0.3));
+  border-color: rgba(252, 211, 77, 0.7);
+}
+
+.city-card--hot {
+  background: linear-gradient(135deg, rgba(239, 68, 68, 0.35), rgba(234, 179, 8, 0.3));
+  border-color: rgba(248, 113, 113, 0.7);
+}
+
 .city-card:hover,
 .city-card:focus-visible {
   transform: translateY(-4px);

--- a/tests/temperatureStyles.test.js
+++ b/tests/temperatureStyles.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getCityCardTemperatureClass } from "../scripts/temperatureStyles.js";
+
+describe("getCityCardTemperatureClass", () => {
+  it("returns the freezing class for temperatures at or below freezing", () => {
+    assert.equal(getCityCardTemperatureClass(-10), "city-card--freezing");
+    assert.equal(getCityCardTemperatureClass(0), "city-card--freezing");
+  });
+
+  it("returns the cool class for chilly temperatures", () => {
+    assert.equal(getCityCardTemperatureClass(10), "city-card--cool");
+  });
+
+  it("returns the warm class for mild temperatures", () => {
+    assert.equal(getCityCardTemperatureClass(20), "city-card--warm");
+  });
+
+  it("returns the hot class for high temperatures", () => {
+    assert.equal(getCityCardTemperatureClass(32), "city-card--hot");
+  });
+
+  it("throws for non-finite values", () => {
+    assert.throws(() => getCityCardTemperatureClass(Number.NaN), /finite number/);
+  });
+});

--- a/tests/weatherService.test.js
+++ b/tests/weatherService.test.js
@@ -34,7 +34,8 @@ describe("mapWeatherResponse", () => {
     assert.deepEqual(result, {
       name: SAMPLE_CITY.name,
       flagEmoji: SAMPLE_CITY.flagEmoji,
-      temperature: `${temperature.toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`
+      temperatureCelsius: temperature,
+      formattedTemperature: `${temperature.toFixed(TEMPERATURE_DECIMAL_PLACES)}${TEMPERATURE_UNIT}`
     });
   });
 


### PR DESCRIPTION
## Summary
- add a temperature styling helper and use it when building city cards
- expose both numeric and formatted temperatures from the weather service
- introduce temperature-based card gradients with accompanying tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff9269a688327a8faf6a7816ecd31